### PR TITLE
fix: graceful MCP server shutdown

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -435,11 +435,5 @@ func InitMCP(ctx context.Context, db *database.DuckDB, log *slog.Logger) *http.S
 		}
 	}()
 
-	// Monitor context in a separate goroutine
-	go func() {
-		<-ctx.Done()
-		log.Info("MCP server context cancelled")
-	}()
-
 	return mcpServer
 }


### PR DESCRIPTION
Fixed graceful shutdown hanging issue when pressing Ctrl+C.

 **Root causes**:
  1. Variable shadowing - httpServer := api.NewServer() created a local variable, leaving the global nil.
  During shutdown, the HTTP server was never stopped, blocking indefinitely.
  2. Blocking MCP server - http.ListenAndServe() in InitMCP() blocked forever and didn't respect context
  cancellation.

**Changes:**
  - cmd/app/main.go:43 - Fixed httpServer := → httpServer =
  - pkg/mcp/server.go - Restructured InitMCP() to create *http.Server, start it in a goroutine, and return it
  for graceful shutdown
  - cmd/app/main.go:111-116 - Added MCP server shutdown call

  Server now shuts down cleanly on Ctrl+C with all goroutines properly terminated.